### PR TITLE
feat: Implement auto-sizing and scalable HUD

### DIFF
--- a/src/client/java/com/yuki920/bedwarsstats/hud/WhoHud.java
+++ b/src/client/java/com/yuki920/bedwarsstats/hud/WhoHud.java
@@ -27,28 +27,48 @@ public class WhoHud implements HudRenderCallback {
             return;
         }
 
+        // --- Auto-sizing logic ---
+        String title = "Bedwars Stats (/who)";
+        int padding = 5;
+        int titleMargin = 5;
+
+        // Calculate width
+        int maxWidth = textRenderer.getWidth(title);
+        for (String line : lines) {
+            maxWidth = Math.max(maxWidth, textRenderer.getWidth(line));
+        }
+        int contentWidth = maxWidth + (padding * 2);
+
+        // Calculate height
+        int contentHeight = (textRenderer.fontHeight + 2) * (lines.size() + 1) + (padding * 2) + titleMargin;
+
+        // --- End auto-sizing logic ---
+
         int x = config.whoHud.hudX;
         int y = config.whoHud.hudY;
-        int width = config.whoHud.hudWidth;
-        int height = config.whoHud.hudHeight;
+        float scale = config.whoHud.hudScalePercent / 100.0f;
+
+        int finalWidth = (int) (contentWidth * scale);
+        int finalHeight = (int) (contentHeight * scale);
 
         // Draw background
-        drawContext.fill(x, y, x + width, y + height, 0x80000000); // Semi-transparent black
+        drawContext.fill(x, y, x + finalWidth, y + finalHeight, 0x80000000); // Semi-transparent black
+
+        drawContext.getMatrices().push();
+        drawContext.getMatrices().translate(x, y, 0);
+        drawContext.getMatrices().scale(scale, scale, 1.0f);
 
         // Draw title
-        String title = "Bedwars Stats (/who)";
         int titleWidth = textRenderer.getWidth(title);
-        drawContext.drawText(textRenderer, title, x + (width - titleWidth) / 2, y + 5, 0xFFFFFF, true);
+        drawContext.drawText(textRenderer, title, (contentWidth - titleWidth) / 2, padding, 0xFFFFFF, true);
 
         // Draw stats
-        int lineY = y + 20;
+        int lineY = padding + textRenderer.fontHeight + titleMargin;
         for (String line : lines) {
-            if (lineY > y + height - 10) {
-                // Stop drawing if it overflows the HUD area
-                break;
-            }
-            drawContext.drawText(textRenderer, Text.literal(line), x + 5, lineY, 0xFFFFFF, false);
-            lineY += 10;
+            drawContext.drawText(textRenderer, Text.literal(line), padding, lineY, 0xFFFFFF, false);
+            lineY += (textRenderer.fontHeight + 2);
         }
+
+        drawContext.getMatrices().pop();
     }
 }

--- a/src/main/java/com/yuki920/bedwarsstats/config/BedwarsStatsConfig.java
+++ b/src/main/java/com/yuki920/bedwarsstats/config/BedwarsStatsConfig.java
@@ -20,16 +20,14 @@ public class BedwarsStatsConfig implements ConfigData {
         @Comment("Enable/Disable the HUD that shows stats from /who")
         public boolean showWhoHud = true;
 
+        @Comment("Change the overall size of the HUD (in percent)")
+        @ConfigEntry.BoundedDiscrete(min = 50, max = 300)
+        public int hudScalePercent = 100;
+
         @ConfigEntry.Gui.Excluded
         public int hudX = 10;
 
         @ConfigEntry.Gui.Excluded
         public int hudY = 10;
-
-        @ConfigEntry.Gui.Excluded
-        public int hudWidth = 250;
-
-        @ConfigEntry.Gui.Excluded
-        public int hudHeight = 150;
     }
 }


### PR DESCRIPTION
This commit refactors the HUD to be dynamic and user-configurable.

- The HUD rendering logic in `WhoHud.java` now calculates the necessary width and height based on the content of the player list, ensuring all text fits within the background.
- A `hudScalePercent` option has been added to the config, rendered as a slider from 50% to 300%. This value is used to scale the entire HUD element, preserving its aspect ratio.
- The `HudEditorScreen` has been updated to remove the manual resizing and now only handles positioning, showing an accurately scaled preview to the user.
- This resolves the issue of text overflowing and not all players being visible in larger game modes.