### PR TITLE
feat: Add startup check for invalid API key

### DIFF
--- a/src/client/java/com/yuki920/bedwarsstats/BedwarsStatsClient.java
+++ b/src/client/java/com/yuki920/bedwarsstats/BedwarsStatsClient.java
@@ -1,14 +1,21 @@
 package com.yuki920.bedwarsstats;
 
 import com.yuki920.bedwarsstats.commands.BwmCommand;
+import com.yuki920.bedwarsstats.commands.BwmCommand;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
 import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 
 public class BedwarsStatsClient implements ClientModInitializer {
     @Override
     public void onInitializeClient() {
         ClientCommandRegistrationCallback.EVENT.register(BwmCommand::register);
+
+        // Add the API key check on server join
+        ClientPlayConnectionEvents.JOIN.register((handler, sender, client) -> {
+            HypixelApiHandler.checkApiKeyValidity();
+        });
 
         ClientReceiveMessageEvents.GAME.register((message, signedMessage) -> {
             String text = message.getString();

--- a/src/client/java/com/yuki920/bedwarsstats/HypixelApiHandler.java
+++ b/src/client/java/com/yuki920/bedwarsstats/HypixelApiHandler.java
@@ -17,6 +17,31 @@ import java.util.concurrent.CompletableFuture;
 public class HypixelApiHandler {
     private static final Gson GSON = new Gson();
     private static final String HYPIXEL_API_URL = "https://api.hypixel.net/player?uuid=";
+    private static final String HYPIXEL_KEY_API_URL = "https://api.hypixel.net/key";
+
+    public static void checkApiKeyValidity() {
+        CompletableFuture.runAsync(() -> {
+            try {
+                BedwarsStatsConfig config = AutoConfig.getConfigHolder(BedwarsStatsConfig.class).getConfig();
+                String apiKey = config.apiKey;
+
+                if (apiKey == null || apiKey.isEmpty()) {
+                    return; // No key set, so nothing to check.
+                }
+
+                String response = sendHttpRequest(HYPIXEL_KEY_API_URL, apiKey);
+                if (response == null) return; // Request failed, but don't spam chat.
+
+                JsonObject json = GSON.fromJson(response, JsonObject.class);
+                if (json != null && !json.get("success").getAsBoolean()) {
+                    sendMessageToPlayer("§c[BedwarsStats] Your Hypixel API key appears to be invalid or expired!");
+                    sendMessageToPlayer("§eRun §a/bwm settings setapikey <key> §eto set a new one.");
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+    }
 
     public static void processPlayer(String username) {
         CompletableFuture.runAsync(() -> {


### PR DESCRIPTION
Adds a check that runs when the player joins a server to validate the Hypixel API key. If the key is invalid or expired, a warning message is displayed in chat. The check is performed by making a request to the /key API endpoint. This feature is triggered by the ClientPlayConnectionEvents.JOIN event.