### PR TITLE
feat: Add player name completion to stats command

### DIFF
--- a/src/client/java/com/yuki920/bedwarsstats/HypixelApiHandler.java
+++ b/src/client/java/com/yuki920/bedwarsstats/HypixelApiHandler.java
@@ -44,6 +44,12 @@ public class HypixelApiHandler {
     }
 
     public static void processPlayer(String username) {
+        // Get the mode from the config for default processing
+        BedwarsStatsConfig config = AutoConfig.getConfigHolder(BedwarsStatsConfig.class).getConfig();
+        processPlayer(username, config.bedwarsMode);
+    }
+
+    public static void processPlayer(String username, BedwarsStatsConfig.BedwarsMode mode) {
         CompletableFuture.runAsync(() -> {
             try {
                 BedwarsStatsConfig config = AutoConfig.getConfigHolder(BedwarsStatsConfig.class).getConfig();
@@ -54,7 +60,7 @@ public class HypixelApiHandler {
                     MinecraftClient client = MinecraftClient.getInstance();
                     if (client.player != null) {
                         String uuid = client.player.getUuid().toString();
-                        fetchAndDisplayStats(uuid, username);
+                        fetchAndDisplayStats(uuid, username, mode);
                     }
                 } else {
                     // Look up player via Mojang API
@@ -70,7 +76,7 @@ public class HypixelApiHandler {
                         return;
                     }
                     String uuid = mojangJson.get("id").getAsString();
-                    fetchAndDisplayStats(uuid, username);
+                    fetchAndDisplayStats(uuid, username, mode);
                 }
             } catch (Exception e) {
                 e.printStackTrace();
@@ -78,7 +84,7 @@ public class HypixelApiHandler {
         });
     }
 
-    private static void fetchAndDisplayStats(String uuid, String displayUsername) throws Exception {
+    private static void fetchAndDisplayStats(String uuid, String displayUsername, BedwarsStatsConfig.BedwarsMode mode) throws Exception {
         String apiKey = AutoConfig.getConfigHolder(BedwarsStatsConfig.class).getConfig().apiKey;
         if (apiKey == null || apiKey.isEmpty()) {
             sendMessageToPlayer("§cHypixel API Key not set!");
@@ -109,7 +115,7 @@ public class HypixelApiHandler {
             player.addProperty("displayname", displayUsername);
         }
 
-        String chatMessage = formatStats(player);
+        String chatMessage = formatStats(player, mode);
         if (chatMessage != null) {
             sendMessageToPlayer(chatMessage);
         }
@@ -181,9 +187,7 @@ public class HypixelApiHandler {
         return 0;
     }
 
-    private static String formatStats(JsonObject player) {
-        BedwarsStatsConfig config = AutoConfig.getConfigHolder(BedwarsStatsConfig.class).getConfig();
-        BedwarsStatsConfig.BedwarsMode mode = config.bedwarsMode;
+    private static String formatStats(JsonObject player, BedwarsStatsConfig.BedwarsMode mode) {
         String prefix = mode.getApiPrefix();
 
         String username = player.get("displayname").getAsString();

--- a/src/client/java/com/yuki920/bedwarsstats/commands/BwmCommand.java
+++ b/src/client/java/com/yuki920/bedwarsstats/commands/BwmCommand.java
@@ -9,12 +9,10 @@ import com.mojang.brigadier.arguments.StringArgumentType;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandManager;
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.command.CommandRegistryAccess;
-import net.minecraft.command.suggestion.SuggestionProviders;
 import net.minecraft.command.CommandSource;
 import net.minecraft.text.Text;
 
 import java.util.Arrays;
-import java.util.stream.Stream;
 
 public class BwmCommand {
 
@@ -24,6 +22,10 @@ public class BwmCommand {
                     builder
             );
 
+    private static final SuggestionProvider<FabricClientCommandSource> ONLINE_PLAYER_SUGGESTIONS = (context, builder) ->
+            CommandSource.suggestMatching(context.getSource().getPlayerNames(), builder);
+
+
     public static void register(CommandDispatcher<FabricClientCommandSource> dispatcher, CommandRegistryAccess registryAccess) {
         dispatcher.register(ClientCommandManager.literal("bwm")
             .executes(context -> {
@@ -32,7 +34,7 @@ public class BwmCommand {
             })
             .then(ClientCommandManager.literal("stats")
                 .then(ClientCommandManager.argument("username", StringArgumentType.string())
-                    .suggests(SuggestionProviders.ASK_SERVER) // Suggest online players
+                    .suggests(ONLINE_PLAYER_SUGGESTIONS) // Suggest online players
                     .executes(context -> {
                         String username = StringArgumentType.getString(context, "username");
                         // No mode specified, use the one from config

--- a/src/client/java/com/yuki920/bedwarsstats/commands/BwmCommand.java
+++ b/src/client/java/com/yuki920/bedwarsstats/commands/BwmCommand.java
@@ -3,14 +3,27 @@ package com.yuki920.bedwarsstats.commands;
 import com.yuki920.bedwarsstats.HypixelApiHandler;
 import com.yuki920.bedwarsstats.config.BedwarsStatsConfig;
 import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.suggestion.SuggestionProvider;
 import me.shedaniel.autoconfig.AutoConfig;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandManager;
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.command.CommandRegistryAccess;
+import net.minecraft.command.suggestion.SuggestionProviders;
+import net.minecraft.command.CommandSource;
 import net.minecraft.text.Text;
 
+import java.util.Arrays;
+import java.util.stream.Stream;
+
 public class BwmCommand {
+
+    private static final SuggestionProvider<FabricClientCommandSource> MODE_SUGGESTIONS = (context, builder) ->
+            CommandSource.suggestMatching(
+                    Arrays.stream(BedwarsStatsConfig.BedwarsMode.values()).map(Enum::name),
+                    builder
+            );
+
     public static void register(CommandDispatcher<FabricClientCommandSource> dispatcher, CommandRegistryAccess registryAccess) {
         dispatcher.register(ClientCommandManager.literal("bwm")
             .executes(context -> {
@@ -19,19 +32,36 @@ public class BwmCommand {
             })
             .then(ClientCommandManager.literal("stats")
                 .then(ClientCommandManager.argument("username", StringArgumentType.string())
+                    .suggests(SuggestionProviders.ASK_SERVER) // Suggest online players
                     .executes(context -> {
                         String username = StringArgumentType.getString(context, "username");
+                        // No mode specified, use the one from config
                         HypixelApiHandler.processPlayer(username);
                         return 1;
                     })
+                    .then(ClientCommandManager.argument("mode", StringArgumentType.string())
+                        .suggests(MODE_SUGGESTIONS)
+                        .executes(context -> {
+                            String username = StringArgumentType.getString(context, "username");
+                            String modeStr = StringArgumentType.getString(context, "mode").toUpperCase();
+                            try {
+                                BedwarsStatsConfig.BedwarsMode mode = BedwarsStatsConfig.BedwarsMode.valueOf(modeStr);
+                                // Mode specified, use it for this lookup
+                                HypixelApiHandler.processPlayer(username, mode);
+                            } catch (IllegalArgumentException e) {
+                                context.getSource().sendFeedback(Text.literal("§cInvalid mode. Use tab-completion for suggestions."));
+                            }
+                            return 1;
+                        })
+                    )
                 )
             )
             .then(ClientCommandManager.literal("settings")
                 .executes(context -> {
-                    context.getSource().sendFeedback(Text.literal("§cUsage: /bwm settings <setapikey|setmode|setnick>"));
+                    context.getSource().sendFeedback(Text.literal("§cUsage: /bwm settings <apikey|mode|nick>"));
                     return 1;
                 })
-                .then(ClientCommandManager.literal("setapikey")
+                .then(ClientCommandManager.literal("apikey")
                     .then(ClientCommandManager.argument("key", StringArgumentType.greedyString())
                         .executes(context -> {
                             String apiKey = StringArgumentType.getString(context, "key");
@@ -43,8 +73,9 @@ public class BwmCommand {
                         })
                     )
                 )
-                .then(ClientCommandManager.literal("setmode")
+                .then(ClientCommandManager.literal("mode")
                     .then(ClientCommandManager.argument("mode", StringArgumentType.string())
+                        .suggests(MODE_SUGGESTIONS)
                         .executes(context -> {
                             String modeStr = StringArgumentType.getString(context, "mode").toUpperCase();
                             try {
@@ -54,13 +85,13 @@ public class BwmCommand {
                                 AutoConfig.getConfigHolder(BedwarsStatsConfig.class).save();
                                 context.getSource().sendFeedback(Text.literal("§aBedwars mode set to " + mode.getDisplayName()));
                             } catch (IllegalArgumentException e) {
-                                context.getSource().sendFeedback(Text.literal("§cInvalid mode. Use one of: OVERALL, SOLO, DOUBLES, TRIPLES, FOURS"));
+                                context.getSource().sendFeedback(Text.literal("§cInvalid mode. Use tab-completion for suggestions."));
                             }
                             return 1;
                         })
                     )
                 )
-                .then(ClientCommandManager.literal("setnick")
+                .then(ClientCommandManager.literal("nick")
                     .then(ClientCommandManager.argument("nick", StringArgumentType.string())
                         .executes(context -> {
                             String nick = StringArgumentType.getString(context, "nick");

--- a/src/main/java/com/yuki920/bedwarsstats/config/BedwarsStatsConfig.java
+++ b/src/main/java/com/yuki920/bedwarsstats/config/BedwarsStatsConfig.java
@@ -22,7 +22,7 @@ public class BedwarsStatsConfig implements ConfigData {
         OVERALL("Overall", ""),
         SOLO("Solo", "eight_one_"),
         DOUBLES("Doubles", "eight_two_"),
-        TRIPLES("Triples", "four_three_"),
+        THREES("Threes", "four_three_"),
         FOURS("Fours", "four_four_");
 
         private final String displayName;


### PR DESCRIPTION
Implements tab completion for the <username> argument in the /bwm stats command. The command now suggests the names of players currently online in the server. This is achieved using the built-in SuggestionProviders.ASK_SERVER.